### PR TITLE
fix: add filter effects to core module

### DIFF
--- a/src/angular2-instagram-core.module.ts
+++ b/src/angular2-instagram-core.module.ts
@@ -1,8 +1,12 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
+import { EffectsModule } from '@ngrx/effects';
 import { FiltersActions } from './actions';
 import { FiltersService } from './services';
+import { FiltersEffects } from './effects/filters-effects';
 
-@NgModule({})
+@NgModule({
+  imports: [EffectsModule.run(FiltersEffects)]
+})
 export class Angular2InstagramCoreModule {
   /**
    * @description Use this method in your other (non root) modules to import the services


### PR DESCRIPTION
Hi @JayKan after testing this in https://github.com/JayKan/angular2-instagram I noticed that the `LOAD_IMAGES` action was not working, I suppose because `FilterEffects` were not initialized in the core module.

So I guessed this fix, let me know what you think.

_OT. If I edit something in this repo and would like to test the outcome in eg. `angular2-instragram`, how should I proceed?_

Thanks